### PR TITLE
Use the ci_cd_automation branch of juicer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "juicer"]
 	path = juicer
 	url = https://github.com/eubr-bigsea/juicer.git
-	branch = master
+	branch = ci_cd_automation
 [submodule "tahiti"]
 	path = tahiti
 	url = https://github.com/eubr-bigsea/tahiti.git


### PR DESCRIPTION
Hi,

I've found problems when building the docker images of the service. When I run the command `docker-compose up -d --build` I receive the next error:

`Step 13/22 : RUN curl -s ${SPARK_HADOOP_URL} | tar -xz -C /usr/local/    && mv /usr/local/$SPARK_HADOOP_PKG $SPARK_HOME
 ---> Running in efe2895f7b27

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
ERROR: Service 'juicer' failed to build: The command '/bin/sh -c curl -s ${SPARK_HADOOP_URL} | tar -xz -C /usr/local/    && mv /usr/local/$SPARK_HADOOP_PKG $SPARK_HOME' returned a non-zero code: 2
`

This error is solved when I use the ci_cd_automation branch of juicer.
Thank you!